### PR TITLE
Check array size before access

### DIFF
--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -295,7 +295,8 @@ class Renderer extends Visitor {
         if (object is List) {
             try {
                 final int index = int.parse(name);
-                return (_integerTag.hasMatch(name) ? object[index] : noSuchProperty);
+                return ((_integerTag.hasMatch(name) && object.length > index)
+                  ? object[index] : noSuchProperty);
             }
             on FormatException {
                 return noSuchProperty;


### PR DESCRIPTION
Currently, using `{{ array.0 }}` on an empty list throws a RangeError.
With this change, the error is caught and only throws with `lenient: false`